### PR TITLE
Pin pnpm 10 in the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
       # pnpm
       - uses: pnpm/action-setup@v6
         with:
+          version: 10
           run_install: false
 
       # Node + registry auth


### PR DESCRIPTION
Pins pnpm to major 10 in the publish workflow. The setup step was unpinned, and pnpm 11 no longer owns `--no-git-checks` — it forwards the flag to npm, and npm 12 (freshly self-updated in the previous step) hard-errors on unknown flags, failing every npm publish.