### PR TITLE
Pin the npm self-update to major 11

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,6 @@ jobs:
       # pnpm
       - uses: pnpm/action-setup@v6
         with:
-          version: 10
           run_install: false
 
       # Node + registry auth
@@ -35,7 +34,7 @@ jobs:
           cache: "pnpm"
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       # Install dependencies
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Root cause of today's publish failures: the workflow self-updates npm to latest, which now resolves to npm 12 — and npm 12 hard-errors on the config pnpm forwards during `pnpm publish` (`--git-checks`), which npm ≤11 tolerated. Every repo already pins pnpm 10.x via `packageManager`, so the fix is pinning the npm update to major 11 (and removing the earlier action-level pnpm pin, which conflicts with `packageManager`).