### PR TITLE
Scope push CI to main and add concurrency guards

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,16 @@
 name: Checks
 
-on: [ pull_request, push ]
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+concurrency:
+  # Superseded runs cancel per workflow+ref (PR merge refs and branch pushes
+  # alike); main is pinned to a unique group (run_id) so every commit on main
+  # gets its own uncancellable verification run.
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   # Code formatting.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  # Superseded runs cancel per workflow+ref (PR merge refs and branch pushes
+  # alike); main is pinned to a unique group (run_id) so every commit on main
+  # gets its own uncancellable verification run.
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   test:
     name: JavaScript/TypeScript Tests


### PR DESCRIPTION
CI hygiene, no behavior change to the jobs' actual work:

- `checks.yml`'s unfiltered `push` trigger is scoped to `main` — PR branches no longer double-run it (they already run via `pull_request`), while every commit on `main` still gets verified.
- Concurrency guards: superseded PR runs cancel; runs on `main` are pinned to a unique group so they can never be cancelled by a follow-up push.