### PR TITLE
Stage externalBin sidecars; keep parent-path resources inside the package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,3 +43,31 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: ./coverage/coverage-final.json
+
+  # Packs a real .msix with the bundled msixbundle-cli sidecar (win32-only,
+  # installed automatically by pnpm via optionalDependencies) and asserts the
+  # artifact's actual contents. TWB_REQUIRE_INTEGRATION makes a silent skip
+  # impossible: on this job a missing cli fails the build.
+  integration:
+    name: MSIX artifact verification
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Verify packaged artifact
+        run: pnpm exec vitest run tests/integration.pack.test.ts
+        env:
+          TWB_REQUIRE_INTEGRATION: '1'

--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ Note: `runFullTrust` is always auto-added (required for Tauri apps).
 - `description` ← `bundle.shortDescription`
 - `publisher` ← `bundle.publisher` (fallback when not in bundle.config.json)
 - `icons` ← `bundle.icon`
-- `resources` ← `bundle.resources`
+- `resources` ← `bundle.resources` (array entries keep their layout; leading `../` maps to `_up_/` and an absolute root to `_root_/`, matching where Tauri's `resolveResource()` looks at runtime)
+- `externalBin` ← `bundle.externalBin` (sidecars staged beside the exe with the `-<target-triple>` suffix stripped; a missing declared sidecar fails the build)
 - `signing` ← `bundle.windows.certificateThumbprint`
 
 **Platform-specific config:** Values in `tauri.windows.conf.json` override `tauri.conf.json` using [JSON Merge Patch (RFC 7396)](https://datatracker.ietf.org/doc/html/rfc7396). This lets you define Windows-specific settings like `identifier`, `productName`, or `bundle.publisher` separately.

--- a/src/core/appx-content.ts
+++ b/src/core/appx-content.ts
@@ -64,7 +64,9 @@ export function prepareAppxContent(
   // Copy bundled resources from tauri.conf.json
   const resourceCount = copyBundledResources(projectRoot, appxDir, tauriConfig);
 
-  console.log(`Staged ${arch}: 1 executable, ${sidecarCount} sidecar(s), ${resourceCount} resource file(s)`);
+  console.log(
+    `Staged ${arch}: 1 executable, ${sidecarCount} sidecar(s), ${resourceCount} resource file(s)`
+  );
 
   return appxDir;
 }

--- a/src/core/appx-content.ts
+++ b/src/core/appx-content.ts
@@ -79,8 +79,13 @@ export function prepareAppxContent(
  * segments instead would put the files where the runtime never searches.
  */
 export function resourceRelpath(p: string): string {
-  const parts = p.split(/[\\/]+/).filter((c) => c !== '' && c !== '.');
-  return parts.map((c) => (c === '..' ? '_up_' : c)).join('/');
+  const absolute = path.isAbsolute(p) || /^[A-Za-z]:[\\/]/.test(p);
+  const parts = p
+    .replace(/^[A-Za-z]:/, '')
+    .split(/[\\/]+/)
+    .filter((c) => c !== '' && c !== '.');
+  const mapped = parts.map((c) => (c === '..' ? '_up_' : c));
+  return (absolute ? ['_root_', ...mapped] : mapped).join('/');
 }
 
 function assertInside(appxDir: string, dest: string, what: string): void {
@@ -169,7 +174,7 @@ function copyBundledResources(
     const files = matches.length > 0 ? matches : [src];
 
     for (const file of files) {
-      const absSrc = path.join(srcDir, file);
+      const absSrc = path.isAbsolute(file) ? file : path.join(srcDir, file);
       if (!fs.existsSync(absSrc)) {
         console.warn(`Warning: bundle.resources entry "${src}" matched nothing at ${absSrc}`);
         continue;

--- a/src/core/appx-content.ts
+++ b/src/core/appx-content.ts
@@ -46,6 +46,9 @@ export function prepareAppxContent(
 
   fs.copyFileSync(srcExe, path.join(appxDir, exeName));
 
+  // Copy sidecars from tauri.conf.json bundle.externalBin
+  const sidecarCount = copyExternalBinSidecars(srcTauriDir, appxDir, tauriConfig, target, exeName);
+
   // Generate AppxManifest.xml
   const manifest = generateManifest(config, arch, minVersion, windowsDir);
   fs.writeFileSync(path.join(appxDir, 'AppxManifest.xml'), manifest);
@@ -59,18 +62,95 @@ export function prepareAppxContent(
   }
 
   // Copy bundled resources from tauri.conf.json
-  copyBundledResources(projectRoot, appxDir, tauriConfig);
+  const resourceCount = copyBundledResources(projectRoot, appxDir, tauriConfig);
+
+  console.log(`Staged ${arch}: 1 executable, ${sidecarCount} sidecar(s), ${resourceCount} resource file(s)`);
 
   return appxDir;
+}
+
+/**
+ * The in-package path for a resource, matching Tauri's own mapping: every `..`
+ * component becomes `_up_` (and an absolute-path root would be `_root_`), so
+ * `../templates` lands at `_up_/templates` — exactly where Tauri's
+ * `resolveResource("../templates")` looks at runtime. Stripping the `..`
+ * segments instead would put the files where the runtime never searches.
+ */
+export function resourceRelpath(p: string): string {
+  const parts = p.split(/[\\/]+/).filter((c) => c !== '' && c !== '.');
+  return parts.map((c) => (c === '..' ? '_up_' : c)).join('/');
+}
+
+function assertInside(appxDir: string, dest: string, what: string): void {
+  const root = path.resolve(appxDir);
+  // Backslashes are separators in the MSIX world even when this runs on POSIX,
+  // so "..\\evil" must count as traversal on every host.
+  const resolved = path.resolve(dest.replace(/\\/g, '/'));
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+    throw new Error(
+      `${what} resolves outside the package root: "${dest}" — the file would silently be left out of the .msix`
+    );
+  }
+}
+
+/**
+ * Stages `bundle.externalBin` sidecars next to the main executable, the way the
+ * official bundler does: the configured string gets `-<target-triple>.exe`
+ * appended to locate the vendored file (globs with `*` are expanded), and the
+ * copy drops both the directory and the triple so `tauri-plugin-shell` can
+ * resolve `sidecar("name")` as `<exe dir>/name.exe`. A configured sidecar with
+ * no matching file fails the build — a package missing its sidecar installs
+ * fine and breaks only at runtime.
+ */
+function copyExternalBinSidecars(
+  srcTauriDir: string,
+  appxDir: string,
+  tauriConfig: TauriConfig,
+  target: string,
+  exeName: string
+): number {
+  const externalBin = tauriConfig.bundle?.externalBin;
+  if (!externalBin || externalBin.length === 0) return 0;
+
+  const seen = new Set<string>([exeName.toLowerCase()]);
+  let count = 0;
+
+  for (const entry of externalBin) {
+    const suffixed = `${entry}-${target}.exe`;
+    // Globs expand for absolute and relative entries alike (Tauri accepts both).
+    const pattern = suffixed.replace(/\\/g, '/');
+    const matches = glob.sync(pattern, path.isAbsolute(suffixed) ? {} : { cwd: srcTauriDir });
+
+    if (matches.length === 0) {
+      throw new Error(
+        `Sidecar not found: ${suffixed} (declared in bundle.externalBin as "${entry}")`
+      );
+    }
+
+    for (const match of matches) {
+      const absSrc = path.isAbsolute(match) ? match : path.join(srcTauriDir, match);
+      const packagedName = `${path.basename(match, `-${target}.exe`)}.exe`;
+      const key = packagedName.toLowerCase();
+      if (seen.has(key)) {
+        throw new Error(
+          `Sidecar name collision: "${packagedName}" is already staged (from bundle.externalBin "${entry}")`
+        );
+      }
+      seen.add(key);
+      fs.copyFileSync(absSrc, path.join(appxDir, packagedName));
+      count += 1;
+    }
+  }
+  return count;
 }
 
 function copyBundledResources(
   projectRoot: string,
   appxDir: string,
   tauriConfig: TauriConfig
-): void {
+): number {
   const resources = tauriConfig.bundle?.resources;
-  if (!resources) return;
+  if (!resources) return 0;
 
   const srcDir = path.join(projectRoot, 'src-tauri');
 
@@ -81,23 +161,29 @@ function copyBundledResources(
     ? resources.map((r) => (typeof r === 'string' ? { src: r } : { src: r.src, target: r.target }))
     : Object.entries(resources).map(([src, target]) => ({ src, target }));
 
+  let count = 0;
   for (const { src, target } of entries) {
     const matches = glob.sync(src, { cwd: srcDir });
     const files = matches.length > 0 ? matches : [src];
 
     for (const file of files) {
       const absSrc = path.join(srcDir, file);
-      if (!fs.existsSync(absSrc)) continue;
+      if (!fs.existsSync(absSrc)) {
+        console.warn(`Warning: bundle.resources entry "${src}" matched nothing at ${absSrc}`);
+        continue;
+      }
 
       let dest: string;
       if (target === undefined) {
-        dest = path.join(appxDir, file);
+        // Array form keeps the relative layout, with `..` mapped like Tauri does.
+        dest = path.join(appxDir, resourceRelpath(file));
       } else if (matches.length > 1 || /[*?[\]]/.test(src)) {
         // Map form with a glob: flatten into target dir.
         dest = path.join(appxDir, target, path.basename(file));
       } else {
         dest = path.join(appxDir, target);
       }
+      assertInside(appxDir, dest, `bundle.resources entry "${src}"`);
 
       fs.mkdirSync(path.dirname(dest), { recursive: true });
       if (fs.statSync(absSrc).isDirectory()) {
@@ -105,6 +191,8 @@ function copyBundledResources(
       } else {
         fs.copyFileSync(absSrc, dest);
       }
+      count += 1;
     }
   }
+  return count;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface TauriConfig {
     longDescription?: string;
     publisher?: string;
     resources?: (string | { src: string; target: string })[] | Record<string, string>;
+    externalBin?: string[];
     fileAssociations?: TauriFileAssociation[];
     windows?: {
       certificateThumbprint?: string;

--- a/tests/appx-content.test.ts
+++ b/tests/appx-content.test.ts
@@ -461,7 +461,14 @@ describe('bundled resources with parent-directory paths (#128)', () => {
     fs.writeFileSync(path.join(shared, 'a.txt'), 'x');
 
     const tauriConfig: TauriConfig = { bundle: { resources: ['../shared'] } };
-    const appxDir = prepareAppxContent(tempDir, 'x64', mockConfig, tauriConfig, '10.0.17763.0', windowsDir);
+    const appxDir = prepareAppxContent(
+      tempDir,
+      'x64',
+      mockConfig,
+      tauriConfig,
+      '10.0.17763.0',
+      windowsDir
+    );
 
     expect(fs.existsSync(path.join(appxDir, '_up_', 'shared', 'a.txt'))).toBe(true);
     // and nothing escaped to the sibling of the package root
@@ -473,7 +480,14 @@ describe('bundled resources with parent-directory paths (#128)', () => {
     fs.writeFileSync(rootFile, 'x');
 
     const tauriConfig: TauriConfig = { bundle: { resources: ['../root.txt'] } };
-    const appxDir = prepareAppxContent(tempDir, 'x64', mockConfig, tauriConfig, '10.0.17763.0', windowsDir);
+    const appxDir = prepareAppxContent(
+      tempDir,
+      'x64',
+      mockConfig,
+      tauriConfig,
+      '10.0.17763.0',
+      windowsDir
+    );
 
     expect(fs.existsSync(path.join(appxDir, '_up_', 'root.txt'))).toBe(true);
   });
@@ -525,7 +539,14 @@ describe('externalBin sidecars (#127)', () => {
     fs.writeFileSync(path.join(binDir, `mytool-${triple}.exe`), 'sidecar');
 
     const tauriConfig: TauriConfig = { bundle: { externalBin: ['binaries/mytool'] } };
-    const appxDir = prepareAppxContent(tempDir, 'x64', mockConfig, tauriConfig, '10.0.17763.0', windowsDir);
+    const appxDir = prepareAppxContent(
+      tempDir,
+      'x64',
+      mockConfig,
+      tauriConfig,
+      '10.0.17763.0',
+      windowsDir
+    );
 
     expect(fs.existsSync(path.join(appxDir, 'mytool.exe'))).toBe(true);
     expect(fs.existsSync(path.join(appxDir, `mytool-${triple}.exe`))).toBe(false);
@@ -546,7 +567,14 @@ describe('externalBin sidecars (#127)', () => {
     fs.writeFileSync(path.join(binDir, `two-${triple}.exe`), 'b');
 
     const tauriConfig: TauriConfig = { bundle: { externalBin: ['bin/*'] } };
-    const appxDir = prepareAppxContent(tempDir, 'x64', mockConfig, tauriConfig, '10.0.17763.0', windowsDir);
+    const appxDir = prepareAppxContent(
+      tempDir,
+      'x64',
+      mockConfig,
+      tauriConfig,
+      '10.0.17763.0',
+      windowsDir
+    );
 
     expect(fs.existsSync(path.join(appxDir, 'one.exe'))).toBe(true);
     expect(fs.existsSync(path.join(appxDir, 'two.exe'))).toBe(true);
@@ -619,7 +647,14 @@ describe('staging hardening (codex round)', () => {
     const tauriConfig: TauriConfig = {
       bundle: { externalBin: [path.join(outside, 'abs-tool')] },
     };
-    const appxDir = prepareAppxContent(tempDir, 'x64', mockConfig, tauriConfig, '10.0.17763.0', windowsDir);
+    const appxDir = prepareAppxContent(
+      tempDir,
+      'x64',
+      mockConfig,
+      tauriConfig,
+      '10.0.17763.0',
+      windowsDir
+    );
     expect(fs.existsSync(path.join(appxDir, 'abs-tool.exe'))).toBe(true);
     fs.rmSync(outside, { recursive: true, force: true });
   });

--- a/tests/appx-content.test.ts
+++ b/tests/appx-content.test.ts
@@ -659,3 +659,14 @@ describe('staging hardening (codex round)', () => {
     fs.rmSync(outside, { recursive: true, force: true });
   });
 });
+
+describe('resource path mapping parity with tauri (_root_)', () => {
+  it('maps absolute resource paths under _root_', async () => {
+    const { resourceRelpath } = await import('../src/core/appx-content.js');
+    expect(resourceRelpath('../x')).toBe('_up_/x');
+    expect(resourceRelpath('../../x/y')).toBe('_up_/_up_/x/y');
+    expect(resourceRelpath('/opt/data/file.txt')).toBe('_root_/opt/data/file.txt');
+    expect(resourceRelpath('C:\\data\\file.txt')).toBe('_root_/data/file.txt');
+    expect(resourceRelpath('plain/dir')).toBe('plain/dir');
+  });
+});

--- a/tests/appx-content.test.ts
+++ b/tests/appx-content.test.ts
@@ -425,3 +425,202 @@ describe('prepareAppxContent', () => {
     expect(manifestContent).not.toContain('{{');
   });
 });
+
+describe('bundled resources with parent-directory paths (#128)', () => {
+  let tempDir: string;
+  let windowsDir: string;
+  let buildDir: string;
+
+  const mockConfig: MergedConfig = {
+    displayName: 'TestApp',
+    version: '1.0.0.0',
+    description: 'A test application',
+    identifier: 'com.example.testapp',
+    publisher: 'CN=TestCompany',
+    publisherDisplayName: 'Test Company',
+    capabilities: { general: ['internetClient'] },
+  };
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tauri-bundle-test-'));
+    windowsDir = path.join(tempDir, 'src-tauri', 'gen', 'windows');
+    fs.mkdirSync(windowsDir, { recursive: true });
+    generateManifestTemplate(windowsDir);
+    buildDir = path.join(tempDir, 'src-tauri', 'target', 'x86_64-pc-windows-msvc', 'release');
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(path.join(buildDir, 'TestApp.exe'), 'mock exe');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('maps a "../" array resource to _up_/ inside the package root', () => {
+    const shared = path.join(tempDir, 'shared');
+    fs.mkdirSync(shared, { recursive: true });
+    fs.writeFileSync(path.join(shared, 'a.txt'), 'x');
+
+    const tauriConfig: TauriConfig = { bundle: { resources: ['../shared'] } };
+    const appxDir = prepareAppxContent(tempDir, 'x64', mockConfig, tauriConfig, '10.0.17763.0', windowsDir);
+
+    expect(fs.existsSync(path.join(appxDir, '_up_', 'shared', 'a.txt'))).toBe(true);
+    // and nothing escaped to the sibling of the package root
+    expect(fs.existsSync(path.join(appxDir, '..', 'shared'))).toBe(false);
+  });
+
+  it('maps multiple leading "../" segments to nested _up_/ directories', () => {
+    const rootFile = path.join(tempDir, 'root.txt');
+    fs.writeFileSync(rootFile, 'x');
+
+    const tauriConfig: TauriConfig = { bundle: { resources: ['../root.txt'] } };
+    const appxDir = prepareAppxContent(tempDir, 'x64', mockConfig, tauriConfig, '10.0.17763.0', windowsDir);
+
+    expect(fs.existsSync(path.join(appxDir, '_up_', 'root.txt'))).toBe(true);
+  });
+
+  it('rejects a map-form target that escapes the package root', () => {
+    const dataFile = path.join(tempDir, 'src-tauri', 'data.json');
+    fs.writeFileSync(dataFile, '{}');
+
+    const tauriConfig: TauriConfig = { bundle: { resources: { 'data.json': '../evil.json' } } };
+    expect(() =>
+      prepareAppxContent(tempDir, 'x64', mockConfig, tauriConfig, '10.0.17763.0', windowsDir)
+    ).toThrow(/outside the package root/);
+  });
+});
+
+describe('externalBin sidecars (#127)', () => {
+  let tempDir: string;
+  let windowsDir: string;
+
+  const mockConfig: MergedConfig = {
+    displayName: 'TestApp',
+    version: '1.0.0.0',
+    description: 'A test application',
+    identifier: 'com.example.testapp',
+    publisher: 'CN=TestCompany',
+    publisherDisplayName: 'Test Company',
+    capabilities: { general: ['internetClient'] },
+  };
+
+  const triple = 'x86_64-pc-windows-msvc';
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tauri-bundle-test-'));
+    windowsDir = path.join(tempDir, 'src-tauri', 'gen', 'windows');
+    fs.mkdirSync(windowsDir, { recursive: true });
+    generateManifestTemplate(windowsDir);
+    const buildDir = path.join(tempDir, 'src-tauri', 'target', triple, 'release');
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(path.join(buildDir, 'TestApp.exe'), 'mock exe');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('copies a sidecar beside the exe without the target-triple suffix', () => {
+    const binDir = path.join(tempDir, 'src-tauri', 'binaries');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, `mytool-${triple}.exe`), 'sidecar');
+
+    const tauriConfig: TauriConfig = { bundle: { externalBin: ['binaries/mytool'] } };
+    const appxDir = prepareAppxContent(tempDir, 'x64', mockConfig, tauriConfig, '10.0.17763.0', windowsDir);
+
+    expect(fs.existsSync(path.join(appxDir, 'mytool.exe'))).toBe(true);
+    expect(fs.existsSync(path.join(appxDir, `mytool-${triple}.exe`))).toBe(false);
+    expect(fs.existsSync(path.join(appxDir, 'binaries'))).toBe(false);
+  });
+
+  it('fails the build when a declared sidecar is missing', () => {
+    const tauriConfig: TauriConfig = { bundle: { externalBin: ['binaries/ghost'] } };
+    expect(() =>
+      prepareAppxContent(tempDir, 'x64', mockConfig, tauriConfig, '10.0.17763.0', windowsDir)
+    ).toThrow(/Sidecar not found: .*ghost-x86_64-pc-windows-msvc\.exe/);
+  });
+
+  it('expands * patterns the way the official bundler does', () => {
+    const binDir = path.join(tempDir, 'src-tauri', 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, `one-${triple}.exe`), 'a');
+    fs.writeFileSync(path.join(binDir, `two-${triple}.exe`), 'b');
+
+    const tauriConfig: TauriConfig = { bundle: { externalBin: ['bin/*'] } };
+    const appxDir = prepareAppxContent(tempDir, 'x64', mockConfig, tauriConfig, '10.0.17763.0', windowsDir);
+
+    expect(fs.existsSync(path.join(appxDir, 'one.exe'))).toBe(true);
+    expect(fs.existsSync(path.join(appxDir, 'two.exe'))).toBe(true);
+  });
+
+  it('rejects a sidecar that would overwrite the main executable', () => {
+    const binDir = path.join(tempDir, 'src-tauri', 'binaries');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, `TestApp-${triple}.exe`), 'impostor');
+
+    const tauriConfig: TauriConfig = { bundle: { externalBin: ['binaries/TestApp'] } };
+    expect(() =>
+      prepareAppxContent(tempDir, 'x64', mockConfig, tauriConfig, '10.0.17763.0', windowsDir)
+    ).toThrow(/collision/);
+  });
+});
+
+describe('staging hardening (codex round)', () => {
+  let tempDir: string;
+  let windowsDir: string;
+  const triple = 'x86_64-pc-windows-msvc';
+
+  const mockConfig: MergedConfig = {
+    displayName: 'TestApp',
+    version: '1.0.0.0',
+    description: 'A test application',
+    identifier: 'com.example.testapp',
+    publisher: 'CN=TestCompany',
+    publisherDisplayName: 'Test Company',
+    capabilities: { general: ['internetClient'] },
+  };
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tauri-bundle-test-'));
+    windowsDir = path.join(tempDir, 'src-tauri', 'gen', 'windows');
+    fs.mkdirSync(windowsDir, { recursive: true });
+    generateManifestTemplate(windowsDir);
+    const buildDir = path.join(tempDir, 'src-tauri', 'target', triple, 'release');
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(path.join(buildDir, 'TestApp.exe'), 'mock exe');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('rejects a backslash-traversal map target on any host', () => {
+    fs.writeFileSync(path.join(tempDir, 'src-tauri', 'data.json'), '{}');
+    const tauriConfig: TauriConfig = { bundle: { resources: { 'data.json': '..\\evil.json' } } };
+    expect(() =>
+      prepareAppxContent(tempDir, 'x64', mockConfig, tauriConfig, '10.0.17763.0', windowsDir)
+    ).toThrow(/outside the package root/);
+  });
+
+  it('rejects two sidecars that collide on the packaged name', () => {
+    for (const dir of ['a', 'b']) {
+      const d = path.join(tempDir, 'src-tauri', dir);
+      fs.mkdirSync(d, { recursive: true });
+      fs.writeFileSync(path.join(d, `tool-${triple}.exe`), dir);
+    }
+    const tauriConfig: TauriConfig = { bundle: { externalBin: ['a/tool', 'b/tool'] } };
+    expect(() =>
+      prepareAppxContent(tempDir, 'x64', mockConfig, tauriConfig, '10.0.17763.0', windowsDir)
+    ).toThrow(/collision/);
+  });
+
+  it('stages a sidecar declared with an absolute path', () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'twb-abs-bin-'));
+    fs.writeFileSync(path.join(outside, `abs-tool-${triple}.exe`), 'x');
+    const tauriConfig: TauriConfig = {
+      bundle: { externalBin: [path.join(outside, 'abs-tool')] },
+    };
+    const appxDir = prepareAppxContent(tempDir, 'x64', mockConfig, tauriConfig, '10.0.17763.0', windowsDir);
+    expect(fs.existsSync(path.join(appxDir, 'abs-tool.exe'))).toBe(true);
+    fs.rmSync(outside, { recursive: true, force: true });
+  });
+});

--- a/tests/integration.pack.test.ts
+++ b/tests/integration.pack.test.ts
@@ -3,7 +3,6 @@ import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import * as zlib from 'node:zlib';
 import { Image, write } from 'image-js';
 import { prepareAppxContent } from '../src/core/appx-content.js';
 import { resolveMsixbundleCliCommand } from '../src/utils/exec.js';
@@ -14,77 +13,44 @@ import type { MergedConfig, TauriConfig } from '../src/types.js';
 
 /**
  * True-artifact integration test: stages a fixture app, packs it with the REAL
- * msixbundle-cli, then parses the produced bundle's zip structure and asserts
- * what actually shipped. No mocks anywhere on that path.
+ * msixbundle-cli (the win32 npm sidecar on CI), then unpacks the result with
+ * Microsoft's own makeappx.exe — which validates the package structure and
+ * block-map hashes while extracting — and asserts what actually shipped.
+ * No mocks anywhere on that path.
  *
- * Skips (visibly) when msixbundle-cli is not installed; CI installs it.
+ * Runs on Windows with the SDK present (CI: windows-latest). Elsewhere it
+ * skips with a visible warning; with TWB_REQUIRE_INTEGRATION=1 a missing
+ * prerequisite fails the run instead.
  */
 
 const cliCommand = resolveMsixbundleCliCommand();
 const cliAvailable = spawnSync(cliCommand, ['--version'], { encoding: 'utf8' }).status === 0;
-// On the dedicated CI job a missing cli must fail loudly, never skip.
-if (process.env.TWB_REQUIRE_INTEGRATION === '1' && !cliAvailable) {
-  throw new Error(`TWB_REQUIRE_INTEGRATION is set but "${cliCommand}" is not runnable`);
-}
 
-// --- Minimal zip reader -----------------------------------------------------
-// A .msixbundle is a zip of .msix files; a .msix is a zip of the package
-// content. Entries are read from the central directory (the authoritative
-// index per APPNOTE.TXT); deflate/store payloads are supported.
-
-interface ZipEntry {
-  name: string;
-  compressedSize: number;
-  uncompressedSize: number;
-  method: number;
-  localHeaderOffset: number;
-}
-
-function readZipEntries(buf: Buffer): ZipEntry[] {
-  // End of central directory record: scan back for its signature.
-  let eocd = -1;
-  for (let i = buf.length - 22; i >= Math.max(0, buf.length - 22 - 65535); i--) {
-    if (buf.readUInt32LE(i) === 0x06054b50) {
-      eocd = i;
-      break;
-    }
+function findMakeAppx(): string | null {
+  if (process.platform !== 'win32') return null;
+  const kitsBin = 'C:\\Program Files (x86)\\Windows Kits\\10\\bin';
+  if (!fs.existsSync(kitsBin)) return null;
+  const versions = fs
+    .readdirSync(kitsBin)
+    .filter((d) => /^10\.\d+/.test(d))
+    .sort()
+    .reverse();
+  for (const v of versions) {
+    const candidate = path.join(kitsBin, v, 'x64', 'makeappx.exe');
+    if (fs.existsSync(candidate)) return candidate;
   }
-  if (eocd < 0) throw new Error('not a zip: no end-of-central-directory record');
-  const count = buf.readUInt16LE(eocd + 10);
-  let offset = buf.readUInt32LE(eocd + 16);
-
-  const entries: ZipEntry[] = [];
-  for (let i = 0; i < count; i++) {
-    if (buf.readUInt32LE(offset) !== 0x02014b50) {
-      throw new Error(`bad central directory entry at ${offset}`);
-    }
-    const method = buf.readUInt16LE(offset + 10);
-    const compressedSize = buf.readUInt32LE(offset + 20);
-    const uncompressedSize = buf.readUInt32LE(offset + 24);
-    const nameLen = buf.readUInt16LE(offset + 28);
-    const extraLen = buf.readUInt16LE(offset + 30);
-    const commentLen = buf.readUInt16LE(offset + 32);
-    const localHeaderOffset = buf.readUInt32LE(offset + 42);
-    const name = buf.subarray(offset + 46, offset + 46 + nameLen).toString('utf8');
-    entries.push({ name, compressedSize, uncompressedSize, method, localHeaderOffset });
-    offset += 46 + nameLen + extraLen + commentLen;
-  }
-  return entries;
+  return null;
 }
 
-function readZipEntryData(buf: Buffer, entry: ZipEntry): Buffer {
-  const lh = entry.localHeaderOffset;
-  if (buf.readUInt32LE(lh) !== 0x04034b50) throw new Error(`bad local header for ${entry.name}`);
-  const nameLen = buf.readUInt16LE(lh + 26);
-  const extraLen = buf.readUInt16LE(lh + 28);
-  const start = lh + 30 + nameLen + extraLen;
-  const raw = buf.subarray(start, start + entry.compressedSize);
-  if (entry.method === 0) return Buffer.from(raw);
-  if (entry.method === 8) return zlib.inflateRawSync(raw);
-  throw new Error(`unsupported compression method ${entry.method} for ${entry.name}`);
-}
+const makeAppx = findMakeAppx();
+const ready = cliAvailable && makeAppx !== null;
 
-// --- Fixture ----------------------------------------------------------------
+if (process.env.TWB_REQUIRE_INTEGRATION === '1' && !ready) {
+  throw new Error(
+    `TWB_REQUIRE_INTEGRATION is set but prerequisites are missing: ` +
+      `msixbundle-cli runnable=${cliAvailable} (via "${cliCommand}"), makeappx=${makeAppx ?? 'not found'}`
+  );
+}
 
 const triple = 'x86_64-pc-windows-msvc';
 
@@ -98,12 +64,9 @@ const mockConfig: MergedConfig = {
   capabilities: { general: ['internetClient'] },
 };
 
-describe.runIf(cliAvailable)('msix artifact contents (real msixbundle-cli)', () => {
+describe.runIf(ready)('msix artifact contents (msixbundle-cli + makeappx)', () => {
   let tempDir: string;
-  let bundlePath: string;
-  let outerEntries: ZipEntry[];
-  let innerBuf: Buffer;
-  let innerEntries: ZipEntry[];
+  let unpackDir: string;
 
   beforeAll(async () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'twb-integration-'));
@@ -153,85 +116,97 @@ describe.runIf(cliAvailable)('msix artifact contents (real msixbundle-cli)', () 
       windowsDir
     );
 
+    // Pack with the real cli; it produces both the per-arch .msix and the bundle
     const outDir = path.join(tempDir, 'msix-out');
-    const result = spawnSync(cliCommand, ['--force', '--out-dir', outDir, '--dir-x64', appxDir], {
+    const pack = spawnSync(cliCommand, ['--force', '--out-dir', outDir, '--dir-x64', appxDir], {
       encoding: 'utf8',
     });
-    expect(result.status, `msixbundle-cli failed:\n${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(pack.status, `msixbundle-cli failed:\n${pack.stdout}\n${pack.stderr}`).toBe(0);
 
-    const produced = fs.readdirSync(outDir).filter((f) => /\.(msixbundle|msix)$/i.test(f));
-    expect(produced.length, `expected one artifact in ${outDir}, got: ${produced.join(', ')}`).toBe(
-      1
+    const produced = fs.readdirSync(outDir);
+    const bundle = produced.find((f) => f.toLowerCase().endsWith('.msixbundle'));
+    const msix = produced.find((f) => f.toLowerCase().endsWith('.msix'));
+    expect(bundle, `no .msixbundle in ${outDir}: ${produced.join(', ')}`).toBeDefined();
+    expect(msix, `no .msix in ${outDir}: ${produced.join(', ')}`).toBeDefined();
+
+    // Unbundle with Microsoft's tool, then unpack the inner package.
+    // makeappx validates the block map and file hashes while extracting.
+    const unbundleDir = path.join(tempDir, 'unbundled');
+    const unbundle = spawnSync(
+      makeAppx as string,
+      ['unbundle', '/p', path.join(outDir, bundle as string), '/d', unbundleDir],
+      { encoding: 'utf8' }
     );
-    bundlePath = path.join(outDir, produced[0]);
+    expect(
+      unbundle.status,
+      `makeappx unbundle failed:\n${unbundle.stdout}\n${unbundle.stderr}`
+    ).toBe(0);
+    const innerMsix = fs.readdirSync(unbundleDir).find((f) => f.toLowerCase().endsWith('.msix'));
+    expect(innerMsix, 'bundle contains no .msix').toBeDefined();
 
-    const outerBuf = fs.readFileSync(bundlePath);
-    outerEntries = readZipEntries(outerBuf);
-    if (bundlePath.toLowerCase().endsWith('.msixbundle')) {
-      const inner = outerEntries.find((e) => e.name.toLowerCase().endsWith('.msix'));
-      expect(inner, 'bundle contains no .msix').toBeDefined();
-      innerBuf = readZipEntryData(outerBuf, inner as ZipEntry);
-    } else {
-      innerBuf = outerBuf;
-    }
-    innerEntries = readZipEntries(innerBuf);
-  }, 120000);
+    unpackDir = path.join(tempDir, 'unpacked');
+    const unpack = spawnSync(
+      makeAppx as string,
+      ['unpack', '/p', path.join(unbundleDir, innerMsix as string), '/d', unpackDir],
+      { encoding: 'utf8' }
+    );
+    expect(unpack.status, `makeappx unpack failed:\n${unpack.stdout}\n${unpack.stderr}`).toBe(0);
+  }, 180000);
 
   afterAll(() => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
   it('ships the main executable and the sidecar without the triple suffix', () => {
-    const names = innerEntries.map((e) => e.name);
-    expect(names).toContain('TestApp.exe');
-    expect(names).toContain('helper.exe');
-    expect(names.some((n) => n.includes(triple))).toBe(false);
+    expect(fs.existsSync(path.join(unpackDir, 'TestApp.exe'))).toBe(true);
+    expect(fs.existsSync(path.join(unpackDir, 'helper.exe'))).toBe(true);
+    const everything = fs.readdirSync(unpackDir, { recursive: true }) as string[];
+    expect(everything.some((n) => n.includes(triple))).toBe(false);
   });
 
   it('ships parent-path resources under _up_/ and map resources at their target', () => {
-    const names = innerEntries.map((e) => e.name);
-    expect(names).toContain('_up_/shared/catalog.json');
-    expect(names).toContain('docs/notes.txt');
-    expect(names.some((n) => n.includes('..'))).toBe(false);
+    expect(fs.existsSync(path.join(unpackDir, '_up_', 'shared', 'catalog.json'))).toBe(true);
+    expect(fs.readFileSync(path.join(unpackDir, 'docs', 'notes.txt'), 'utf8')).toBe(
+      'mapped resource'
+    );
   });
 
   it('ships every declared icon variant with real image bytes', () => {
-    const names = innerEntries.map((e) => e.name);
+    const assets = path.join(unpackDir, 'Assets');
     for (const size of TARGET_SIZES) {
-      expect(names).toContain(`Assets/Square44x44Logo.targetsize-${size}.png`);
-      expect(names).toContain(`Assets/Square44x44Logo.targetsize-${size}_altform-unplated.png`);
-      expect(names).toContain(
-        `Assets/Square44x44Logo.targetsize-${size}_altform-lightunplated.png`
-      );
+      expect(fs.existsSync(path.join(assets, `Square44x44Logo.targetsize-${size}.png`))).toBe(true);
+      expect(
+        fs.existsSync(path.join(assets, `Square44x44Logo.targetsize-${size}_altform-unplated.png`))
+      ).toBe(true);
+      expect(
+        fs.existsSync(
+          path.join(assets, `Square44x44Logo.targetsize-${size}_altform-lightunplated.png`)
+        )
+      ).toBe(true);
     }
     for (const factor of SCALE_FACTORS) {
-      expect(names).toContain(`Assets/Square150x150Logo.scale-${factor}.png`);
+      expect(fs.existsSync(path.join(assets, `Square150x150Logo.scale-${factor}.png`))).toBe(true);
     }
-    // Every shipped PNG carries a PNG signature after decompression
-    const png = innerEntries.find((e) => e.name === 'Assets/Square44x44Logo.targetsize-48.png');
-    const data = readZipEntryData(innerBuf, png as ZipEntry);
-    expect(data.subarray(0, 8)).toEqual(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
+    const png = fs.readFileSync(path.join(assets, 'Square44x44Logo.targetsize-48.png'));
+    expect(png.subarray(0, 8)).toEqual(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
   });
 
   it('declares the staged executable in the packaged AppxManifest.xml', () => {
-    const manifest = innerEntries.find((e) => e.name === 'AppxManifest.xml');
-    expect(manifest).toBeDefined();
-    const xml = readZipEntryData(innerBuf, manifest as ZipEntry).toString('utf8');
+    const xml = fs.readFileSync(path.join(unpackDir, 'AppxManifest.xml'), 'utf8');
     expect(xml).toContain('Executable="TestApp.exe"');
     expect(xml).toContain('Publisher="CN=TestCompany"');
   });
 
-  it('shipped payload sizes match the staged files', () => {
-    const sidecar = innerEntries.find((e) => e.name === 'helper.exe') as ZipEntry;
-    expect(readZipEntryData(innerBuf, sidecar).toString('utf8')).toBe('MZ sidecar');
+  it('shipped payload bytes match the staged files', () => {
+    expect(fs.readFileSync(path.join(unpackDir, 'helper.exe'), 'utf8')).toBe('MZ sidecar');
   });
 });
 
-describe.runIf(!cliAvailable)('msix artifact contents (real msixbundle-cli)', () => {
-  it('SKIPPED: msixbundle-cli is not runnable here (win32 sidecar or PATH install) — artifact verification did not run', () => {
+describe.runIf(!ready)('msix artifact contents (msixbundle-cli + makeappx)', () => {
+  it('SKIPPED: prerequisites missing — artifact verification did not run', () => {
     console.warn(
-      'integration.pack.test.ts skipped: install msixbundle-cli (cargo install msixbundle-cli) to verify real package contents'
+      `integration.pack.test.ts skipped: msixbundle-cli runnable=${cliAvailable}, makeappx=${makeAppx ?? 'not found'} — runs on Windows with the SDK`
     );
-    expect(cliAvailable).toBe(false);
+    expect(ready).toBe(false);
   });
 });

--- a/tests/integration.pack.test.ts
+++ b/tests/integration.pack.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as zlib from 'node:zlib';
+import { Image, write } from 'image-js';
+import { prepareAppxContent } from '../src/core/appx-content.js';
+import { resolveMsixbundleCliCommand } from '../src/utils/exec.js';
+import { generateManifestTemplate } from '../src/core/manifest.js';
+import { generateAssets } from '../src/generators/assets.js';
+import { TARGET_SIZES, SCALE_FACTORS } from '../src/types.js';
+import type { MergedConfig, TauriConfig } from '../src/types.js';
+
+/**
+ * True-artifact integration test: stages a fixture app, packs it with the REAL
+ * msixbundle-cli, then parses the produced bundle's zip structure and asserts
+ * what actually shipped. No mocks anywhere on that path.
+ *
+ * Skips (visibly) when msixbundle-cli is not installed; CI installs it.
+ */
+
+const cliCommand = resolveMsixbundleCliCommand();
+const cliAvailable = spawnSync(cliCommand, ['--version'], { encoding: 'utf8' }).status === 0;
+// On the dedicated CI job a missing cli must fail loudly, never skip.
+if (process.env.TWB_REQUIRE_INTEGRATION === '1' && !cliAvailable) {
+  throw new Error(`TWB_REQUIRE_INTEGRATION is set but "${cliCommand}" is not runnable`);
+}
+
+// --- Minimal zip reader -----------------------------------------------------
+// A .msixbundle is a zip of .msix files; a .msix is a zip of the package
+// content. Entries are read from the central directory (the authoritative
+// index per APPNOTE.TXT); deflate/store payloads are supported.
+
+interface ZipEntry {
+  name: string;
+  compressedSize: number;
+  uncompressedSize: number;
+  method: number;
+  localHeaderOffset: number;
+}
+
+function readZipEntries(buf: Buffer): ZipEntry[] {
+  // End of central directory record: scan back for its signature.
+  let eocd = -1;
+  for (let i = buf.length - 22; i >= Math.max(0, buf.length - 22 - 65535); i--) {
+    if (buf.readUInt32LE(i) === 0x06054b50) {
+      eocd = i;
+      break;
+    }
+  }
+  if (eocd < 0) throw new Error('not a zip: no end-of-central-directory record');
+  const count = buf.readUInt16LE(eocd + 10);
+  let offset = buf.readUInt32LE(eocd + 16);
+
+  const entries: ZipEntry[] = [];
+  for (let i = 0; i < count; i++) {
+    if (buf.readUInt32LE(offset) !== 0x02014b50) {
+      throw new Error(`bad central directory entry at ${offset}`);
+    }
+    const method = buf.readUInt16LE(offset + 10);
+    const compressedSize = buf.readUInt32LE(offset + 20);
+    const uncompressedSize = buf.readUInt32LE(offset + 24);
+    const nameLen = buf.readUInt16LE(offset + 28);
+    const extraLen = buf.readUInt16LE(offset + 30);
+    const commentLen = buf.readUInt16LE(offset + 32);
+    const localHeaderOffset = buf.readUInt32LE(offset + 42);
+    const name = buf.subarray(offset + 46, offset + 46 + nameLen).toString('utf8');
+    entries.push({ name, compressedSize, uncompressedSize, method, localHeaderOffset });
+    offset += 46 + nameLen + extraLen + commentLen;
+  }
+  return entries;
+}
+
+function readZipEntryData(buf: Buffer, entry: ZipEntry): Buffer {
+  const lh = entry.localHeaderOffset;
+  if (buf.readUInt32LE(lh) !== 0x04034b50) throw new Error(`bad local header for ${entry.name}`);
+  const nameLen = buf.readUInt16LE(lh + 26);
+  const extraLen = buf.readUInt16LE(lh + 28);
+  const start = lh + 30 + nameLen + extraLen;
+  const raw = buf.subarray(start, start + entry.compressedSize);
+  if (entry.method === 0) return Buffer.from(raw);
+  if (entry.method === 8) return zlib.inflateRawSync(raw);
+  throw new Error(`unsupported compression method ${entry.method} for ${entry.name}`);
+}
+
+// --- Fixture ----------------------------------------------------------------
+
+const triple = 'x86_64-pc-windows-msvc';
+
+const mockConfig: MergedConfig = {
+  displayName: 'TestApp',
+  version: '1.0.0.0',
+  description: 'Integration fixture',
+  identifier: 'com.example.integration',
+  publisher: 'CN=TestCompany',
+  publisherDisplayName: 'Test Company',
+  capabilities: { general: ['internetClient'] },
+};
+
+describe.runIf(cliAvailable)('msix artifact contents (real msixbundle-cli)', () => {
+  let tempDir: string;
+  let bundlePath: string;
+  let outerEntries: ZipEntry[];
+  let innerBuf: Buffer;
+  let innerEntries: ZipEntry[];
+
+  beforeAll(async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'twb-integration-'));
+    const srcTauri = path.join(tempDir, 'src-tauri');
+    const windowsDir = path.join(srcTauri, 'gen', 'windows');
+    fs.mkdirSync(windowsDir, { recursive: true });
+    generateManifestTemplate(windowsDir);
+
+    // Real 310x310 source icon so every variant is generated from real image data
+    const iconsDir = path.join(srcTauri, 'icons');
+    fs.mkdirSync(iconsDir, { recursive: true });
+    const icon = new Image(310, 310, { colorModel: 'RGBA' });
+    await write(path.join(iconsDir, 'icon.png'), icon);
+    fs.copyFileSync(path.join(iconsDir, 'icon.png'), path.join(iconsDir, 'Square44x44Logo.png'));
+    await generateAssets(windowsDir, tempDir, {
+      scale: true,
+      targetSize: true,
+      unplated: true,
+      lightUnplated: true,
+    });
+
+    // Main exe (MZ magic so it is a plausible PE), a sidecar, and resources
+    const buildDir = path.join(srcTauri, 'target', triple, 'release');
+    fs.mkdirSync(buildDir, { recursive: true });
+    fs.writeFileSync(path.join(buildDir, 'TestApp.exe'), Buffer.from('MZ integration fixture'));
+    const binDir = path.join(srcTauri, 'binaries');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, `helper-${triple}.exe`), Buffer.from('MZ sidecar'));
+    const shared = path.join(tempDir, 'shared');
+    fs.mkdirSync(shared, { recursive: true });
+    fs.writeFileSync(path.join(shared, 'catalog.json'), '{"items":[]}');
+    fs.writeFileSync(path.join(srcTauri, 'notes.txt'), 'mapped resource');
+
+    const tauriConfig: TauriConfig = {
+      bundle: {
+        externalBin: ['binaries/helper'],
+        resources: ['../shared', { src: 'notes.txt', target: 'docs/notes.txt' }],
+      },
+    };
+
+    const appxDir = prepareAppxContent(
+      tempDir,
+      'x64',
+      mockConfig,
+      tauriConfig,
+      '10.0.17763.0',
+      windowsDir
+    );
+
+    const outDir = path.join(tempDir, 'msix-out');
+    const result = spawnSync(cliCommand, ['--force', '--out-dir', outDir, '--dir-x64', appxDir], {
+      encoding: 'utf8',
+    });
+    expect(result.status, `msixbundle-cli failed:\n${result.stdout}\n${result.stderr}`).toBe(0);
+
+    const produced = fs.readdirSync(outDir).filter((f) => /\.(msixbundle|msix)$/i.test(f));
+    expect(produced.length, `expected one artifact in ${outDir}, got: ${produced.join(', ')}`).toBe(
+      1
+    );
+    bundlePath = path.join(outDir, produced[0]);
+
+    const outerBuf = fs.readFileSync(bundlePath);
+    outerEntries = readZipEntries(outerBuf);
+    if (bundlePath.toLowerCase().endsWith('.msixbundle')) {
+      const inner = outerEntries.find((e) => e.name.toLowerCase().endsWith('.msix'));
+      expect(inner, 'bundle contains no .msix').toBeDefined();
+      innerBuf = readZipEntryData(outerBuf, inner as ZipEntry);
+    } else {
+      innerBuf = outerBuf;
+    }
+    innerEntries = readZipEntries(innerBuf);
+  }, 120000);
+
+  afterAll(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('ships the main executable and the sidecar without the triple suffix', () => {
+    const names = innerEntries.map((e) => e.name);
+    expect(names).toContain('TestApp.exe');
+    expect(names).toContain('helper.exe');
+    expect(names.some((n) => n.includes(triple))).toBe(false);
+  });
+
+  it('ships parent-path resources under _up_/ and map resources at their target', () => {
+    const names = innerEntries.map((e) => e.name);
+    expect(names).toContain('_up_/shared/catalog.json');
+    expect(names).toContain('docs/notes.txt');
+    expect(names.some((n) => n.includes('..'))).toBe(false);
+  });
+
+  it('ships every declared icon variant with real image bytes', () => {
+    const names = innerEntries.map((e) => e.name);
+    for (const size of TARGET_SIZES) {
+      expect(names).toContain(`Assets/Square44x44Logo.targetsize-${size}.png`);
+      expect(names).toContain(`Assets/Square44x44Logo.targetsize-${size}_altform-unplated.png`);
+      expect(names).toContain(
+        `Assets/Square44x44Logo.targetsize-${size}_altform-lightunplated.png`
+      );
+    }
+    for (const factor of SCALE_FACTORS) {
+      expect(names).toContain(`Assets/Square150x150Logo.scale-${factor}.png`);
+    }
+    // Every shipped PNG carries a PNG signature after decompression
+    const png = innerEntries.find((e) => e.name === 'Assets/Square44x44Logo.targetsize-48.png');
+    const data = readZipEntryData(innerBuf, png as ZipEntry);
+    expect(data.subarray(0, 8)).toEqual(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]));
+  });
+
+  it('declares the staged executable in the packaged AppxManifest.xml', () => {
+    const manifest = innerEntries.find((e) => e.name === 'AppxManifest.xml');
+    expect(manifest).toBeDefined();
+    const xml = readZipEntryData(innerBuf, manifest as ZipEntry).toString('utf8');
+    expect(xml).toContain('Executable="TestApp.exe"');
+    expect(xml).toContain('Publisher="CN=TestCompany"');
+  });
+
+  it('shipped payload sizes match the staged files', () => {
+    const sidecar = innerEntries.find((e) => e.name === 'helper.exe') as ZipEntry;
+    expect(readZipEntryData(innerBuf, sidecar).toString('utf8')).toBe('MZ sidecar');
+  });
+});
+
+describe.runIf(!cliAvailable)('msix artifact contents (real msixbundle-cli)', () => {
+  it('SKIPPED: msixbundle-cli is not runnable here (win32 sidecar or PATH install) — artifact verification did not run', () => {
+    console.warn(
+      'integration.pack.test.ts skipped: install msixbundle-cli (cargo install msixbundle-cli) to verify real package contents'
+    );
+    expect(cliAvailable).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #127, fixes #128.

bundle.externalBin was ignored entirely, so a package with sidecars built, signed and installed cleanly and failed only at runtime. Sidecars are now staged beside the executable with the target-triple suffix stripped (the name tauri-plugin-shell resolves), `*` patterns and absolute paths work, a missing declared sidecar fails the build, and packaged-name collisions (with the main exe or another sidecar) are errors.

bundle.resources entries with leading `../` escaped the package root and silently vanished from the .msix. One correction to the fix suggested in #128: the official bundler does not strip the `../` — it maps every parent component to `_up_/` (`resource_relpath` in tauri-utils), and `resolveResource("../x")` looks under `_up_/x` at runtime, so this implements that mapping. Map-form targets that resolve outside the package root (with either separator) fail the build instead of writing outside it.

The build now prints a one-line staging summary (executable, sidecar and resource counts), and a resources entry that matches nothing warns instead of disappearing silently.