### PR TITLE
Resolve the executable name from Cargo instead of guessing from displayName

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Edit `src-tauri/gen/windows/bundle.config.json`:
 }
 ```
 
+`executableName` (optional) pins the exe filename when derivation is wrong. Without it the name resolves from `mainBinaryName` in tauri.conf.json, then the first `[[bin]]` (else `[package]`) name in src-tauri/Cargo.toml, and only as a last resort from the product name.
+
 `publisher` and `publisherDisplayName` are optional in `bundle.config.json`. If omitted, `publisher` falls back to `bundle.publisher` from `tauri.conf.json` or `tauri.windows.conf.json`. If `publisherDisplayName` is omitted, it defaults to the resolved `publisher` value.
 
 **Capabilities** are validated at build time. Three types are supported:

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -25,7 +25,7 @@ import {
   resolveBundledMsixbundleCliPath,
   resolveMsixbundleCliCommand,
 } from '../utils/exec.js';
-import { getDefaultLanguageFromManifestFile } from '../core/manifest.js';
+import { getDefaultLanguageFromManifestFile, resolveExecutableName } from '../core/manifest.js';
 
 export async function build(options: BuildOptions): Promise<void> {
   console.log('Building MSIX package...\n');
@@ -132,6 +132,21 @@ export async function build(options: BuildOptions): Promise<void> {
     publisher,
     publisherDisplayName,
   };
+
+  // The exe is whatever `tauri build` produced (Cargo bin name unless
+  // mainBinaryName overrides it) — never the displayName.
+  config.executableName = resolveExecutableName(
+    config.executableName,
+    tauriConfig,
+    path.join(projectRoot, 'src-tauri')
+  );
+  if (!config.executableName) {
+    console.warn(
+      'Warning: could not determine the executable name from bundle.config.json (executableName), ' +
+        'tauri.conf.json (mainBinaryName) or src-tauri/Cargo.toml — guessing from productName. ' +
+        'Set one of those if the build fails with "Executable not found".'
+    );
+  }
 
   // Fold file associations declared in tauri.conf.json into the Windows config
   // so they can live in a single source of truth (matching tauri-macos-xcode).

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -53,13 +53,62 @@ export function generateManifestTemplate(windowsDir: string): void {
 }
 
 /**
- * Canonical exe filename derived from `displayName`. Used as the binary's name
- * in the packaged appx root and as the `Executable=` attribute on the main
- * `<Application>` block plus any extension that references the same binary
- * (e.g. `com:ExeServer`, `uap3:Extension Category="windows.appExecutionAlias"`).
+ * Canonical exe filename. Used as the binary's name in the packaged appx root
+ * and as the `Executable=` attribute on the main `<Application>` block plus any
+ * extension that references the same binary (e.g. `com:ExeServer`,
+ * `uap3:Extension Category="windows.appExecutionAlias"`).
+ *
+ * `config.executableName` (resolved once per build by {@link resolveExecutableName})
+ * wins; the historical displayName-derived guess remains only as the last resort.
  */
-export function executableName(config: Pick<MergedConfig, 'displayName'>): string {
+export function executableName(
+  config: Pick<MergedConfig, 'displayName' | 'executableName'>
+): string {
+  if (config.executableName) return config.executableName;
   return `${config.displayName.replace(/\s+/g, '')}.exe`;
+}
+
+/**
+ * Resolves the real name of the binary `tauri build` produced. Tauri v2 does
+ * not rename binaries to the product name: the artifact is the Cargo bin name
+ * unless `mainBinaryName` overrides it. Order: explicit `executableName` in
+ * bundle.config.json → `mainBinaryName` in tauri.conf.json → the first
+ * `[[bin]]` name (else `[package]` name) from src-tauri/Cargo.toml →
+ * undefined, letting {@link executableName} fall back to the displayName guess.
+ */
+export function resolveExecutableName(
+  explicit: string | undefined,
+  tauriConfig: { mainBinaryName?: string },
+  srcTauriDir: string
+): string | undefined {
+  if (explicit) return explicit.toLowerCase().endsWith('.exe') ? explicit : `${explicit}.exe`;
+  if (tauriConfig.mainBinaryName) return `${tauriConfig.mainBinaryName}.exe`;
+  const cargoName = readCargoBinName(srcTauriDir);
+  return cargoName ? `${cargoName}.exe` : undefined;
+}
+
+// Line-oriented, not a full TOML parser: a `[bin]`-looking line inside a
+// multiline string would be misread. Cargo manifests in practice never carry
+// those; both quote styles for `name` are handled.
+function readCargoBinName(srcTauriDir: string): string | undefined {
+  const cargoToml = path.join(srcTauriDir, 'Cargo.toml');
+  if (!fs.existsSync(cargoToml)) return undefined;
+  const lines = fs.readFileSync(cargoToml, 'utf8').split(/\r?\n/);
+  let section = '';
+  let packageName: string | undefined;
+  for (const line of lines) {
+    const header = line.match(/^\s*\[+\s*([^\]]+?)\s*\]+/);
+    if (header) {
+      section = header[1];
+      continue;
+    }
+    const name = line.match(/^\s*name\s*=\s*(?:"([^"]+)"|'([^']+)')/);
+    if (!name) continue;
+    const value = name[1] ?? name[2];
+    if (section === 'bin') return value;
+    if (section === 'package' && packageName === undefined) packageName = value;
+  }
+  return packageName;
 }
 
 export function generateManifest(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export interface TauriConfig {
   productName?: string;
+  mainBinaryName?: string;
   version?: string;
   identifier?: string;
   bundle?: {
@@ -40,6 +41,8 @@ export interface CapabilitiesConfig {
 export interface BundleConfig {
   publisher?: string;
   publisherDisplayName?: string;
+  /** Explicit main executable filename (with or without .exe); overrides every derivation. */
+  executableName?: string;
   resourceIndex?: {
     enabled?: boolean;
     keepConfig?: boolean;

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -502,9 +502,9 @@ describe('resolveExecutableName (#103)', () => {
   });
 
   it('executableName() uses the resolved name over the displayName guess', () => {
-    expect(
-      executableName({ displayName: 'My APP', executableName: 'my_app.exe' })
-    ).toBe('my_app.exe');
+    expect(executableName({ displayName: 'My APP', executableName: 'my_app.exe' })).toBe(
+      'my_app.exe'
+    );
     expect(executableName({ displayName: 'My APP' })).toBe('MyAPP.exe');
   });
 });

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -3,10 +3,12 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import {
+  executableName,
   generateManifest,
   generateManifestTemplate,
   getDefaultLanguageFromManifestXml,
   getDefaultLanguageFromManifestFile,
+  resolveExecutableName,
 } from '../src/core/manifest.js';
 import type { MergedConfig } from '../src/types.js';
 
@@ -454,5 +456,74 @@ describe('getDefaultLanguageFromManifest', () => {
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('resolveExecutableName (#103)', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'twb-exe-name-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('prefers the explicit executableName and appends .exe when missing', () => {
+    expect(resolveExecutableName('custom', {}, tempDir)).toBe('custom.exe');
+    expect(resolveExecutableName('custom.exe', {}, tempDir)).toBe('custom.exe');
+  });
+
+  it('uses tauri.conf.json mainBinaryName next', () => {
+    expect(resolveExecutableName(undefined, { mainBinaryName: 'main-bin' }, tempDir)).toBe(
+      'main-bin.exe'
+    );
+  });
+
+  it('falls back to the first [[bin]] name in Cargo.toml', () => {
+    fs.writeFileSync(
+      path.join(tempDir, 'Cargo.toml'),
+      '[package]\nname = "my-app"\n\n[[bin]]\nname = "custom_bin"\npath = "src/main.rs"\n'
+    );
+    expect(resolveExecutableName(undefined, {}, tempDir)).toBe('custom_bin.exe');
+  });
+
+  it('falls back to the Cargo package name when no [[bin]] exists', () => {
+    fs.writeFileSync(
+      path.join(tempDir, 'Cargo.toml'),
+      '[package]\nname = "my_app"\nversion = "0.1.0"\n\n[dependencies]\nname-like = "1"\n'
+    );
+    expect(resolveExecutableName(undefined, {}, tempDir)).toBe('my_app.exe');
+  });
+
+  it('returns undefined without Cargo.toml so the displayName guess applies', () => {
+    expect(resolveExecutableName(undefined, {}, tempDir)).toBeUndefined();
+  });
+
+  it('executableName() uses the resolved name over the displayName guess', () => {
+    expect(
+      executableName({ displayName: 'My APP', executableName: 'my_app.exe' })
+    ).toBe('my_app.exe');
+    expect(executableName({ displayName: 'My APP' })).toBe('MyAPP.exe');
+  });
+});
+
+describe('readCargoBinName quoting (via resolveExecutableName)', () => {
+  it('accepts single-quoted TOML names', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'twb-toml-'));
+    fs.writeFileSync(path.join(dir, 'Cargo.toml'), "[package]\nname = 'sq_app'\n");
+    expect(resolveExecutableName(undefined, {}, dir)).toBe('sq_app.exe');
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('ignores name keys in unrelated sections', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'twb-toml-'));
+    fs.writeFileSync(
+      path.join(dir, 'Cargo.toml'),
+      '[package.metadata.foo]\nname = "not-it"\n\n[package]\nname = "real_app"\n'
+    );
+    expect(resolveExecutableName(undefined, {}, dir)).toBe('real_app.exe');
+    fs.rmSync(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
Fixes #103.

Tauri v2 never renames the binary to the product name: the artifact is the Cargo bin name unless mainBinaryName overrides it, so deriving the exe from displayName broke every project where the two differ. Resolution order is now: `executableName` in bundle.config.json (new, explicit override) → `mainBinaryName` in tauri.conf.json → the first `[[bin]]` (else `[package]`) name from src-tauri/Cargo.toml → the old displayName guess as a last resort, with a warning. The resolved name flows through the manifest, aliases, toast activation and COM server consistently.