### PR TITLE
Generate the full Microsoft icon target-size matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ npx @choochmeque/tauri-windows-bundle init --all-variants
 | Flag               | Files generated                                                                           |
 | ------------------ | ----------------------------------------------------------------------------------------- |
 | `--scale`          | `<asset>.scale-100/125/150/200/400.png` for StoreLogo, Square44x44Logo, Square150x150Logo |
-| `--target-size`    | `Square44x44Logo.targetsize-16/24/32/48/256.png` (taskbar, Start list, jump lists)        |
+| `--target-size`    | `Square44x44Logo.targetsize-16/20/24/30/32/36/40/48/60/64/72/80/96/256.png` (taskbar, Start list, jump lists)        |
 | `--unplated`       | `Square44x44Logo.targetsize-N_altform-unplated.png` (transparent background)              |
 | `--light-unplated` | `Square44x44Logo.targetsize-N_altform-lightunplated.png` (light theme)                    |
 | `--all-variants`   | All of the above                                                                          |
@@ -194,7 +194,7 @@ target/msix/
 npx @choochmeque/tauri-windows-bundle init [options]
   -p, --path <path>    Path to Tauri project
   --scale              Generate .scale-100/125/150/200/400 PNG variants
-  --target-size        Generate .targetsize-16/24/32/48/256 PNG variants for Square44x44Logo
+  --target-size        Generate .targetsize-16/20/24/30/32/36/40/48/60/64/72/80/96/256 PNG variants for Square44x44Logo
   --unplated           Generate _altform-unplated targetsize variants
   --light-unplated     Generate _altform-lightunplated targetsize variants
   --all-variants       Shortcut for all four variant families above

--- a/src/generators/assets.ts
+++ b/src/generators/assets.ts
@@ -90,6 +90,18 @@ export async function generateAssets(
       );
     } else {
       console.log(`  Generating variants from ${path.basename(sourcePath)}`);
+      try {
+        const probe = await read(sourcePath);
+        const largest = Math.max(...TARGET_SIZES);
+        if (Math.max(probe.width, probe.height) < largest) {
+          console.warn(
+            `    Warning: ${path.basename(sourcePath)} is ${probe.width}x${probe.height}; ` +
+              `variants up to ${largest}px will be upscaled and may look blurry — provide a ≥${largest}px source`
+          );
+        }
+      } catch {
+        // probing is best-effort; generation below reports real read failures
+      }
       if (variants.scale) {
         await generateScaleVariants(assetsDir, sourcePath);
         console.log('    Scale variants written');

--- a/src/types.ts
+++ b/src/types.ts
@@ -159,7 +159,11 @@ export interface VariantOptions {
 }
 
 export const SCALE_FACTORS = [100, 125, 150, 200, 400] as const;
-export const TARGET_SIZES = [16, 24, 32, 48, 256] as const;
+// Microsoft's full app-icon target-size matrix: taskbar/Start at 125-400% display
+// scale request 20/30/36/40/60/64/72/80/96px directly; anything absent gets
+// resampled from another size and can render jagged.
+// https://learn.microsoft.com/en-us/windows/apps/design/iconography/app-icon-construction
+export const TARGET_SIZES = [16, 20, 24, 30, 32, 36, 40, 48, 60, 64, 72, 80, 96, 256] as const;
 
 export interface BuildOptions {
   arch?: string;
@@ -184,7 +188,7 @@ export const MSIX_ASSETS: MsixAsset[] = [
   { name: 'StoreLogo.png', size: 50 },
   { name: 'Square44x44Logo.png', size: 44 },
   { name: 'Square150x150Logo.png', size: 150 },
-  { name: 'Wide310x150Logo.png', width: 310, height: 150, skipScaleVariants: true },
+  { name: 'Wide310x150Logo.png', width: 310, height: 150 },
 ];
 
 export const DEFAULT_MIN_WINDOWS_VERSION = '10.0.17763.0';

--- a/tests/assets.test.ts
+++ b/tests/assets.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { generateAssets, resolveTauriIconsDir } from '../src/generators/assets.js';
-import { MSIX_ASSETS } from '../src/types.js';
+import { MSIX_ASSETS, TARGET_SIZES } from '../src/types.js';
 
 describe('generateAssets', () => {
   let tempDir: string;
@@ -332,13 +332,13 @@ describe('generateAssets variants', () => {
     expect(files.some((f) => f.includes('.targetsize-'))).toBe(false);
   });
 
-  it('generates scale variants for 3 assets x 5 factors (no wide, no LargeTile)', async () => {
+  it('generates scale variants for all 4 declared assets x 5 factors (no LargeTile)', async () => {
     fs.writeFileSync(path.join(iconsDir, 'icon.png'), createTestPng(310, 310));
     await generateAssets(tempDir, projectRoot, { scale: true });
 
     const assetsDir = path.join(tempDir, 'Assets');
     const factors = [100, 125, 150, 200, 400];
-    const bases = ['StoreLogo', 'Square44x44Logo', 'Square150x150Logo'];
+    const bases = ['StoreLogo', 'Square44x44Logo', 'Square150x150Logo', 'Wide310x150Logo'];
 
     for (const base of bases) {
       for (const f of factors) {
@@ -346,15 +346,16 @@ describe('generateAssets variants', () => {
       }
     }
 
-    // Wide tile and LargeTile must not be scaled
     const files = fs.readdirSync(assetsDir);
-    expect(files.some((f) => f.startsWith('Wide310x150Logo.scale-'))).toBe(false);
     expect(files.some((f) => f.startsWith('LargeTile.'))).toBe(false);
 
     // Spot-check dimensions
     const [w, h] = readIhdrWidthHeight(path.join(assetsDir, 'Square150x150Logo.scale-200.png'));
     expect(w).toBe(300);
     expect(h).toBe(300);
+    const [ww, wh] = readIhdrWidthHeight(path.join(assetsDir, 'Wide310x150Logo.scale-200.png'));
+    expect(ww).toBe(620);
+    expect(wh).toBe(300);
   });
 
   it('generates targetSize variants for Square44x44Logo only', async () => {
@@ -362,7 +363,7 @@ describe('generateAssets variants', () => {
     await generateAssets(tempDir, projectRoot, { targetSize: true });
 
     const assetsDir = path.join(tempDir, 'Assets');
-    for (const size of [16, 24, 32, 48, 256]) {
+    for (const size of TARGET_SIZES) {
       expect(fs.existsSync(path.join(assetsDir, `Square44x44Logo.targetsize-${size}.png`))).toBe(
         true
       );
@@ -378,7 +379,7 @@ describe('generateAssets variants', () => {
     await generateAssets(tempDir, projectRoot, { unplated: true, lightUnplated: true });
 
     const assetsDir = path.join(tempDir, 'Assets');
-    for (const size of [16, 24, 32, 48, 256]) {
+    for (const size of TARGET_SIZES) {
       expect(
         fs.existsSync(
           path.join(assetsDir, `Square44x44Logo.targetsize-${size}_altform-unplated.png`)

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   MSIX_ASSETS,
+  TARGET_SIZES,
   DEFAULT_MIN_WINDOWS_VERSION,
   DEFAULT_CAPABILITIES,
   GENERAL_CAPABILITIES,
@@ -39,9 +40,13 @@ describe('MSIX_ASSETS', () => {
     expect(wide?.height).toBe(150);
   });
 
-  it('marks Wide310x150Logo to skip scale variants', () => {
+  it('declares scale variants for Wide310x150Logo (the manifest references it)', () => {
     const wide = MSIX_ASSETS.find((a) => a.name === 'Wide310x150Logo.png');
-    expect(wide?.skipScaleVariants).toBe(true);
+    expect(wide?.skipScaleVariants).toBeUndefined();
+  });
+
+  it('covers the full Microsoft target-size matrix', () => {
+    expect([...TARGET_SIZES]).toEqual([16, 20, 24, 30, 32, 36, 40, 48, 60, 64, 72, 80, 96, 256]);
   });
 });
 


### PR DESCRIPTION
Fixes #89.

The Square44x44Logo target-size families only covered 16/24/32/48/256, but Windows requests 20/30/36/40/60/64/72/80/96 directly at 125–400% display scale and resamples when a size is absent — which is what renders jagged on a 2560×1440 display. The generator now produces Microsoft's full documented matrix for all three families (default, unplated, light-unplated), Wide310x150Logo gets scale variants like every other declared tile, and variant generation warns when the source icon is smaller than the largest requested size (256px).

After updating, re-run `npx @choochmeque/tauri-windows-bundle init --all-variants` and rebuild; Windows caches icons aggressively, so uninstall the previous package first when verifying.