### PR TITLE
README: fix the Rust action name and cache cargo in the CI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,9 +468,16 @@ jobs:
           cache: 'pnpm'
 
       - name: Setup Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc, aarch64-pc-windows-msvc
+
+      # Caches the cargo registry and build artifacts; cuts warm build times
+      # to a fraction of the cold ones.
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
Fixes #3.

The workflow example referenced dtolnay/rust-action, which does not exist (the action is dtolnay/rust-toolchain), and lacked a cargo cache; with Swatinem/rust-cache warm builds drop to a fraction of the cold time, as reported in the issue. The msixbundle-cli note in the example already reflects the bundled sidecar.